### PR TITLE
Improve tuple and vector generation

### DIFF
--- a/Durty.AltV.NativesTypingsGenerator/Converters/NativeReturnTypeToCSharpTypingConverter.cs
+++ b/Durty.AltV.NativesTypingsGenerator/Converters/NativeReturnTypeToCSharpTypingConverter.cs
@@ -26,7 +26,7 @@ namespace Durty.AltV.NativesTypingsGenerator.Converters
                     }
                 }
                 returnTypeForTyping += ")";
-                retrun returnTypeForTyping;
+                return returnTypeForTyping;
             }
             return "object";
         }

--- a/Durty.AltV.NativesTypingsGenerator/Converters/NativeReturnTypeToCSharpTypingConverter.cs
+++ b/Durty.AltV.NativesTypingsGenerator/Converters/NativeReturnTypeToCSharpTypingConverter.cs
@@ -16,10 +16,18 @@ namespace Durty.AltV.NativesTypingsGenerator.Converters
             }
             else if (nativeReturnTypes.Count > 1) 
             {
-                string returnTypeForTyping = "(";
-                for (int i = 0; i < nativeReturnTypes.Count; i++)
+                var returnTypeForTyping = "(";
+                for (var i = 0; i < nativeReturnTypes.Count; i++)
                 {
-                    returnTypeForTyping += nativeTypeToTypingConverter.Convert(native, nativeReturnTypes[i], false);
+                    var tupleReturnType = nativeTypeToTypingConverter.Convert(native, nativeReturnTypes[i], false);
+                    if (tupleReturnType == "void")
+                    {
+                        returnTypeForTyping += "object";
+                    }
+                    else
+                    {
+                        returnTypeForTyping += tupleReturnType;
+                    }
                     if (i != nativeReturnTypes.Count - 1)
                     {
                         returnTypeForTyping += ", ";

--- a/Durty.AltV.NativesTypingsGenerator/TypingDef/TypeDefCSharpFileGenerator.cs
+++ b/Durty.AltV.NativesTypingsGenerator/TypingDef/TypeDefCSharpFileGenerator.cs
@@ -111,7 +111,7 @@ namespace Durty.AltV.NativesTypingsGenerator.TypingDef
                 else if (typeDefFunction.ReturnType.NativeType.Count > 1)
                 {
                     result.Append($"\t\t\var results = (Array) {fixedTypeDefName}.Call(native");
-                    returnTypeForTyping = "return (";
+                    var returnTypeForTyping = "return (";
                     for (int i = 0; i < typeDefFunction.ReturnType.NativeType.Count; i++)
                     {
                         returnTypeForTyping += $"({new NativeTypeToCSharpTypingConverter().Convert(null, typeDefFunction.ReturnType.NativeType[i], false)}) results[{i}]";

--- a/Durty.AltV.NativesTypingsGenerator/TypingDef/TypeDefCSharpFileGenerator.cs
+++ b/Durty.AltV.NativesTypingsGenerator/TypingDef/TypeDefCSharpFileGenerator.cs
@@ -158,7 +158,7 @@ namespace Durty.AltV.NativesTypingsGenerator.TypingDef
                 return $"JSObjectToVector3({returnValue})";
             }
 
-            if (csharpReturnType == "object")
+            if (csharpReturnType == "object" || csharpReturnType == "void")
             {
                 return returnValue;
             }

--- a/Durty.AltV.NativesTypingsGenerator/TypingDef/TypeDefCSharpFileGenerator.cs
+++ b/Durty.AltV.NativesTypingsGenerator/TypingDef/TypeDefCSharpFileGenerator.cs
@@ -102,16 +102,19 @@ namespace Durty.AltV.NativesTypingsGenerator.TypingDef
                 if (typeDefFunction.ReturnType.Name == "any")
                 {
                     result.Append($"\t\t\treturn {fixedTypeDefName}.Call(native");
+                    GenerateCallParameters(result, typeDefFunction);
                 }
                 else if (typeDefFunction.ReturnType.Name == "Vector3")
                 {
-                    result.Append($"\t\t\var vectorObj = (JSObject) {fixedTypeDefName}.Call(native");
-                    result.Append($"\t\t\return new Vector3((float) vectorObj.GetObjectProperty(\"x\"), (float) vectorObj.GetObjectProperty(\"y\"),(float) vectorObj.GetObjectProperty(\"z\"));");
+                    result.Append($"\t\t\tvar vectorObj = (JSObject) {fixedTypeDefName}.Call(native");
+                    GenerateCallParameters(result, typeDefFunction);
+                    result.Append($"\t\t\treturn new Vector3((float) vectorObj.GetObjectProperty(\"x\"), (float) vectorObj.GetObjectProperty(\"y\"),(float) vectorObj.GetObjectProperty(\"z\"));\n");
                 }
                 else if (typeDefFunction.ReturnType.NativeType.Count > 1)
                 {
-                    result.Append($"\t\t\var results = (Array) {fixedTypeDefName}.Call(native");
-                    var returnTypeForTyping = "return (";
+                    result.Append($"\t\t\tvar results = (Array) {fixedTypeDefName}.Call(native");
+                    GenerateCallParameters(result, typeDefFunction);
+                    var returnTypeForTyping = "\t\t\treturn (";
                     for (int i = 0; i < typeDefFunction.ReturnType.NativeType.Count; i++)
                     {
                         returnTypeForTyping += $"({new NativeTypeToCSharpTypingConverter().Convert(null, typeDefFunction.ReturnType.NativeType[i], false)}) results[{i}]";
@@ -120,18 +123,28 @@ namespace Durty.AltV.NativesTypingsGenerator.TypingDef
                             returnTypeForTyping += ", ";
                         }
                     }
-                    returnTypeForTyping += ");";
+                    returnTypeForTyping += ");\n";
                     result.Append(returnTypeForTyping);
                 }
                 else
                 {
                     result.Append($"\t\t\treturn ({cSharpReturnType}) {fixedTypeDefName}.Call(native");
+                    GenerateCallParameters(result, typeDefFunction);
                 }
             }
             else
             {
                 result.Append($"\t\t\t{fixedTypeDefName}.Call(native");
+                GenerateCallParameters(result, typeDefFunction);
             }
+            
+            result.Append($"\t\t}}\n");
+
+            return result;
+        }
+
+        private void GenerateCallParameters(StringBuilder result, TypeDefFunction typeDefFunction)
+        {
             foreach (var parameter in typeDefFunction.Parameters)
             {
                 if (typeDefFunction.Parameters.First() == parameter)
@@ -145,10 +158,6 @@ namespace Durty.AltV.NativesTypingsGenerator.TypingDef
                 }
             }
             result.Append($");\n");
-
-            result.Append($"\t\t}}\n");
-
-            return result;
         }
 
         private StringBuilder GenerateFunctionDocumentation(TypeDefFunction typeDefFunction)

--- a/Durty.AltV.NativesTypingsGenerator/TypingDef/TypeDefCSharpFileGenerator.cs
+++ b/Durty.AltV.NativesTypingsGenerator/TypingDef/TypeDefCSharpFileGenerator.cs
@@ -49,6 +49,7 @@ namespace Durty.AltV.NativesTypingsGenerator.TypingDef
         private StringBuilder GenerateModule(TypeDefModule typeDefModule)
         {
             StringBuilder result = new StringBuilder(string.Empty);
+            result.Append($"using System.Numerics;\n");
             result.Append($"using WebAssembly;\n");
             result.Append($"using WebAssembly.Core;\n\n");
             result.Append($"namespace AltV.Net.Client\n{{\n");

--- a/Durty.AltV.NativesTypingsGenerator/TypingDef/TypeDefCSharpFileGenerator.cs
+++ b/Durty.AltV.NativesTypingsGenerator/TypingDef/TypeDefCSharpFileGenerator.cs
@@ -122,7 +122,7 @@ namespace Durty.AltV.NativesTypingsGenerator.TypingDef
                         var tupleReturnType = typeDefFunction.ReturnType.NativeType[i];
                         var cSharpTupleReturnType =
                             new NativeTypeToCSharpTypingConverter().Convert(null, tupleReturnType, false);
-                        returnTypeForTyping += TransformReturnValue(tupleReturnType, cSharpTupleReturnType, $"results[{i}]");
+                        returnTypeForTyping += TransformReturnValue(cSharpTupleReturnType, $"results[{i}]");
                         if (i != typeDefFunction.ReturnType.NativeType.Count - 1)
                         {
                             returnTypeForTyping += ", ";
@@ -136,7 +136,7 @@ namespace Durty.AltV.NativesTypingsGenerator.TypingDef
                     var returnValue = new StringBuilder();
                     returnValue.Append($"{fixedTypeDefName}.Call(native");
                     GenerateCallParameters(returnValue, typeDefFunction, false);
-                    var transformedResult = TransformReturnValue(typeDefFunction.ReturnType.NativeType.First(), cSharpReturnType, returnValue.ToString());
+                    var transformedResult = TransformReturnValue(cSharpReturnType, returnValue.ToString());
                     result.Append($"\t\t\treturn {transformedResult};\n");
                 }
             }
@@ -151,14 +151,14 @@ namespace Durty.AltV.NativesTypingsGenerator.TypingDef
             return result;
         }
 
-        private string TransformReturnValue(NativeType returnValueType, string csharpReturnType, string returnValue)
+        private string TransformReturnValue(string csharpReturnType, string returnValue)
         {
-            if (returnValueType == NativeType.Vector3)
+            if (csharpReturnType == "Vector3")
             {
                 return $"JSObjectToVector3({returnValue})";
             }
 
-            if (returnValueType == NativeType.Object || returnValueType == NativeType.Void)
+            if (csharpReturnType == "object")
             {
                 return returnValue;
             }


### PR DESCRIPTION
```csharp
public (bool, int) GetMaxAmmo2(int ped, int weaponHash, int ammo)
                {
                        if (getMaxAmmo2 == null) getMaxAmmo2 = (Function) native.GetObjectProperty("getMaxAmmo2");
                        var results = (Array) getMaxAmmo2.Call(native, ped, weaponHash, ammo);
                        return ((bool) results[0], (int) results[1]);
                }
```

```csharp
public (Vector3, object) ObjectValueGetVector3(object objectData, string key)
		{
			if (objectValueGetVector3 == null) objectValueGetVector3 = (Function) native.GetObjectProperty("objectValueGetVector3");
			var results = (Array) objectValueGetVector3.Call(native, objectData, key);
			return (JSObjectToVector3(results[0]), results[1]);
		}
```